### PR TITLE
Add AGENTS.md documenting environment setup for the audit-report archive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository (`1inch/1inch-audits`) is a **static document archive**, not a software application.
+Its content is:
+
+- `README.md` — an index that links to the audit report PDFs.
+- 145 PDF audit reports grouped into per-protocol folders (e.g. `Aggregation Protocol V2/`, `Cross-chain Protocol/`).
+- `LICENSE.md`, `.gitignore`, and two brand SVGs under `.github/`.
+
+There is **no application code, package manifest, build system, test suite, or linter** anywhere in the repo,
+so there is nothing to install, build, lint, or test. Do not add a toolchain or CI unless explicitly asked.
+
+"Development" here means editing `README.md` and adding/removing/renaming PDF files. When adding a report,
+place the PDF in the matching protocol folder and add a corresponding link under the right heading in `README.md`.
+
+### Previewing the archive
+The repo has no dev server of its own. To browse it as it is consumed (folders + PDFs), serve the directory with
+Python's stdlib server (already available, no install) and open it in a browser:
+
+```
+python3 -m http.server 8000
+```
+
+Then visit `http://localhost:8000/`, click into a protocol folder, and click a PDF to render it in the browser's
+PDF viewer. `README.md` links point at GitHub `raw`/`blob` URLs, so those specific links only resolve on GitHub,
+not on the local static server (browse the folders directly instead).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This repo (`1inch/1inch-audits`) is a **static document archive**, not a software application. It contains `README.md` (an index), 145 PDF audit reports in per-protocol folders, `LICENSE.md`, `.gitignore`, and brand SVGs. There is **no application code, package manifest, build system, test suite, or linter**, so there is nothing to install/build/lint/test.

This PR adds an `AGENTS.md` with a `## Cursor Cloud specific instructions` section that:
- Describes the repo as a static PDF archive and what "development" means here (editing `README.md` and managing PDFs).
- Documents how to preview the archive locally via `python3 -m http.server 8000` (no install required), with a note that `README.md` links target GitHub `raw`/`blob` URLs and won't resolve on the local server.

The update script is a no-op (`true`) because there are no dependencies to refresh.

## Verification

Served the archive with `python3 -m http.server 8000` and browsed it end-to-end in Chrome: root directory listing → `Aggregation Protocol V2/` folder → opened `Certik - 1inch v2 Audit Report.pdf`, which rendered correctly in the browser's PDF viewer.

<a href="https://cursor.com/agents/bc-8b8c1998-57aa-4ca3-bc7c-ff9a2745190a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbrowsing_1inch_audit_archive.mp4"><img src="https://cursor.com/artifacts/c/art-2ffd22a0-6272-4f42-bd31-7e75b99c73e2" alt="browsing_1inch_audit_archive.mp4" /></a>

![Root directory listing of audit report folders](https://cursor.com/artifacts/c/art-486738fe-adeb-4e92-9e2b-84566c7b4f56)
![Certik audit report PDF rendered in browser](https://cursor.com/artifacts/c/art-36fdbab2-31d1-4b04-a819-5e1dc137bd97)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b8c1998-57aa-4ca3-bc7c-ff9a2745190a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b8c1998-57aa-4ca3-bc7c-ff9a2745190a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

